### PR TITLE
updated package.json of lx64/v6 with a typo fix and include for 7z.so…

### DIFF
--- a/rrNodeJS_rrBindings/lx64/lib/package.json
+++ b/rrNodeJS_rrBindings/lx64/lib/package.json
@@ -10,6 +10,7 @@
   "files": [
     "librrShared.so.1",
     "libQtCore.so.4",
+    "7z.so",
     "*.node"
   ],
   "author": "",


### PR DESCRIPTION
…, since that is needed for librrShared